### PR TITLE
Get rid of 'escape' characater

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -129,7 +129,8 @@ int getdir (string dir, vector<string> &files){
     	 * no dot files
     	 */
     	bool test = false;
-    	if(*(string(dirp->d_name).begin())=='\.')
+    	//if(*(string(dirp->d_name).begin())=='\.')
+	if(*(string(dirp->d_name).begin())=='.')
 	    test = true;
     	if(test == false){
 	    files.push_back(string(dirp->d_name));


### PR DESCRIPTION
Warning reported during `make`:
```
phlawd_db_maker/src/utils.cpp:132:42: warning: unknown escape sequence: '\.'
      if(*(string(dirp->d_name).begin())=='\.')
                                          ^~~~
```
I _believe_ you just want '.', right? I don't think `begin` supports regex anyway.