### PR TITLE
Minor edits (you might even call it a... Minor Threat?) ( •_•)>⌐■-■ (⌐■_■)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ CMakeFiles
 Makefile
 CMakeCache.txt
 phlawd_db_maker
+cmake_install.cmake
+nbproject
+

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This requires that you have wget. For linux that is simple. For mac, you will ne
 ## Installation
 Installation should be relatively simple. Then you just run `cmake .` in the phlawd_db_maker directory. This should make the necessary files. Then you run `make` and it should compile and make the `phlawd_db_maker` executable.
 
-If you run into problems, it make be the sqlitewrapper. To fix that, just go into the deps/sqlitewrapper directory and type `make clean` and then `make`. Then copy (`cp`) the `libsqlitewrapper.a` into the relevant `deps` directory (so `cp libsqlitewrapper.a ../mac` if you are running a mac and `cp libsqlitewrapper.a ../linux` if you are running a linux). 
+If you run into problems, it make be the sqlitewrapper. To fix that, just go into the deps/sqlitewrapped directory and type `make clean` and then `make`. Then copy (`cp`) the `libsqlitewrapped.a` into the relevant `deps` directory (so `cp libsqlitewrapped.a ../mac` if you are running a mac and `cp libsqlitewrapped.a ../linux` if you are running a linux). 
 
 ## Usage
 All you need to do to run this is pick the division you want (so `pln` for example) and then run

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,8 +44,11 @@ int main(int argc, char* argv[]){
 
 	string division(argv[1]);
         string dbname(argv[2]);
+        
+        // abort early if division is invalid
+        check_valid_division_code(division);
 
-        cout << "setting up database" << endl;
+        cout << "setting up " << division << " database" << endl;
         bool download = true;
 
         SQLiteDBController * c;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -241,3 +241,26 @@ vector<string> query_mask(string url){
 
     return returngis;
 }
+
+// division codes: https://www.ncbi.nlm.nih.gov/genbank/htgs/divisions/
+// purpose here it to abort early if the provided division code is invalid
+// downstream code expects lowercase div code, so do this prior to checking
+// comments if uppercase
+// exits if invalid
+void check_valid_division_code(string & inDiv) {
+    // currently available codes
+    vector<string> divs = {"BCT", "PRI", "ROD", "MAM", "VRT", "INV", "PLN",
+                           "VRL", "PHG", "RNA", "SYN", "UNA"};
+    string test = inDiv;
+    std::transform(test.begin(),test.end(),test.begin(),::toupper);
+    
+    if(std::find(divs.begin(),divs.end(),test)!=divs.end()){
+        if(inDiv==test){
+            // provided div code was uppercase. change to lowercase
+            std::transform(inDiv.begin(),inDiv.end(),inDiv.begin(),::tolower);
+        }
+    } else {
+        cout<<"invalid ncbi division code provided. see https://www.ncbi.nlm.nih.gov/genbank/htgs/divisions"<<endl;
+        exit(0);
+    }
+}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -129,7 +129,8 @@ int getdir (string dir, vector<string> &files){
     	 * no dot files
     	 */
     	bool test = false;
-    	if(*(string(dirp->d_name).begin())=='\.')
+    	//if(*(string(dirp->d_name).begin())=='\.')
+        if(*(string(dirp->d_name).begin())=='.')
 	    test = true;
     	if(test == false){
 	    files.push_back(string(dirp->d_name));

--- a/src/utils.h
+++ b/src/utils.h
@@ -52,4 +52,5 @@ void convert_to_phylip(string,string);
 vector<int> get_left_right_exclude(vector<int> * lefts, vector<int> * rights, vector<int> * exlefts, vector<int> * exrights);
 int get_distance_from_child_to_parent(string ncbidb, string child, string parent);
 
+void check_valid_division_code(string & div);
 #endif


### PR DESCRIPTION
1. check if division code is valid. handles CAPITAL codes (given on the NCBI page) and converts them to lowercase. if invalid, exits.
2. minor typos in README.
3. ignore moar stuff (files made by cmake, netbeans folder).
4. get rid of 'escape' character. Here is the reported warning from make:
```
phlawd_db_maker/src/utils.cpp:132:42: warning: unknown escape sequence: '\.'
      if(*(string(dirp->d_name).begin())=='\.')
                                          ^~~~
```
taking out the '\\' gets rid of the warning. I _think_ you want to get rid of it (I don't believe `begin` supports regex, and I think you want a literal '.' here), but you should check this *carefully*. Maybe related to https://github.com/blackrim/phlawd_db_maker/issues/2.